### PR TITLE
Add common database code

### DIFF
--- a/packages/backend/knexfile.ts
+++ b/packages/backend/knexfile.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+import { loadBackendConfig } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import { getDatabaseConfig } from './src/database/connection';
+
+module.exports = async () => {
+  const configs = await loadBackendConfig();
+  const config = ConfigReader.fromConfigs(configs);
+  const dbConfig = getDatabaseConfig(config);
+
+  return {
+    ...dbConfig,
+    migrations: {
+      directory: path.resolve(__dirname, './migrations'),
+    },
+  };
+};

--- a/packages/backend/migrations/20200809175510_create_auth_db.js
+++ b/packages/backend/migrations/20200809175510_create_auth_db.js
@@ -1,0 +1,22 @@
+const knexUtils = require('../src/database/knexMigrationUtils');
+
+const DATABASE_NAME = 'backstage_plugin_auth';
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
+  return knexUtils.createPostgresDatabase(knex, DATABASE_NAME);
+};
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
+  return knexUtils.dropPostgresDatabase(knex, DATABASE_NAME);
+};
+
+/**
+ * Database creation is not allowed in a transaction
+ */
+exports.config = { transaction: false };

--- a/packages/backend/migrations/20200809175525_create_catalog_db.js
+++ b/packages/backend/migrations/20200809175525_create_catalog_db.js
@@ -1,0 +1,22 @@
+const knexUtils = require('../src/database/knexMigrationUtils');
+
+const DATABASE_NAME = 'backstage_plugin_catalog';
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
+  return knexUtils.createPostgresDatabase(knex, DATABASE_NAME);
+};
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
+  return knexUtils.dropPostgresDatabase(knex, DATABASE_NAME);
+};
+
+/**
+ * Database creation is not allowed in a transaction
+ */
+exports.config = { transaction: false };

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,7 +14,7 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "clean": "backstage-cli clean",
-    "migrate:create": "knex migrate:make -x ts"
+    "migrate:create": "knex migrate:make -x js"
   },
   "dependencies": {
     "@backstage/backend-common": "^0.1.1-alpha.18",

--- a/packages/backend/src/database/connection.test.ts
+++ b/packages/backend/src/database/connection.test.ts
@@ -1,0 +1,47 @@
+import { ConfigReader } from '@backstage/config';
+import { createDatabase } from './connection';
+
+describe('database connection', () => {
+  const createConfig = (data: any = {}) =>
+    ConfigReader.fromConfigs([{ context: '', data: { backend: data } }]);
+
+  describe(createDatabase, () => {
+    it('returns a knex instance', () => {
+      // TODO: Find way to test if this is a postgres client
+      expect(
+        createDatabase(
+          createConfig({
+            POSTGRES_HOST: 'somehost',
+            POSTGRES_USER: 'postgres',
+            POSTGRES_PORT: '5432',
+          }),
+        ),
+      ).toBeTruthy();
+    });
+
+    it('returns an sqlite config by default', () => {
+      // TODO: Find way to test if this is a sqlite client
+      expect(createDatabase(createConfig())).toBeTruthy();
+    });
+  });
+
+  describe(createDatabase, () => {
+    it('returns a knex instance', () => {
+      // TODO: Find way to test if this is a postgres client
+      expect(
+        createDatabase(
+          createConfig({
+            POSTGRES_HOST: 'somehost',
+            POSTGRES_USER: 'postgres',
+            POSTGRES_PORT: '5432',
+          }),
+        ),
+      ).toBeTruthy();
+    });
+
+    it('returns an sqlite config by default', () => {
+      // TODO: Find way to test if this is a sqlite client
+      expect(createDatabase(createConfig())).toBeTruthy();
+    });
+  });
+});

--- a/packages/backend/src/database/connection.ts
+++ b/packages/backend/src/database/connection.ts
@@ -1,0 +1,36 @@
+import knex from 'knex';
+import { Config } from '@backstage/config';
+import { getPgConnectionConfig, hasPostgresConnection } from './postgres';
+
+export function createDatabase(config: Config, dbName?: string) {
+  const knexConfig = getDatabaseConfig(config, dbName);
+  const database = knex(knexConfig);
+
+  database.client.pool.on('createSuccess', (_eventId: any, resource: any) => {
+    resource.run('PRAGMA foreign_keys = ON', () => {});
+  });
+
+  return database;
+}
+
+export function getDatabaseConfig(
+  config: Config,
+  dbName?: string,
+): knex.Config {
+  if (hasPostgresConnection(config)) {
+    return {
+      client: 'pg',
+      connection: getPgConnectionConfig(config, dbName),
+    };
+  }
+
+  return getSqliteConnectionConfig();
+}
+
+function getSqliteConnectionConfig() {
+  return {
+    client: 'sqlite3',
+    connection: ':memory:',
+    useNullAsDefault: true,
+  };
+}

--- a/packages/backend/src/database/index.ts
+++ b/packages/backend/src/database/index.ts
@@ -1,0 +1,2 @@
+export * from './connection';
+export * from './migrations';

--- a/packages/backend/src/database/knexMigrationUtils.js
+++ b/packages/backend/src/database/knexMigrationUtils.js
@@ -1,0 +1,38 @@
+/**
+ * @param {import('knex')} knex
+ * @param string dbName
+ */
+async function createPostgresDatabase(knex, dbName) {
+  if (knex.client.config.client !== 'pg') {
+    return knex;
+  }
+
+  const exists = await knex
+    .raw(
+      `SELECT EXISTS(SELECT datname FROM pg_catalog.pg_database WHERE lower(datname) = lower('${dbName}'));`,
+    )
+    .then(result => result.rows[0].exists);
+
+  if (!exists) {
+    return knex.raw(`
+      CREATE DATABASE ${dbName};
+    `);
+  }
+
+  return knex;
+}
+
+/**
+ * @param {import('knex')} knex
+ * @param string dbName
+ */
+async function dropPostgresDatabase(knex, dbName) {
+  return knex.raw(`
+    DROP DATABASE IF EXISTS ${dbName};
+  `);
+}
+
+module.exports = {
+  createPostgresDatabase,
+  dropPostgresDatabase,
+};

--- a/packages/backend/src/database/migrations.test.ts
+++ b/packages/backend/src/database/migrations.test.ts
@@ -1,0 +1,35 @@
+import Knex from 'knex';
+import { runDatabaseMigrations, resolveMigrationsDir } from './migrations';
+
+function createDb() {
+  const knex = Knex({
+    client: 'sqlite3',
+    connection: ':memory:',
+    useNullAsDefault: true,
+  });
+  knex.client.pool.on('createSuccess', (_eventId: any, resource: any) => {
+    resource.run('PRAGMA foreign_keys = ON', () => {});
+  });
+  return knex;
+}
+
+describe('migrations', () => {
+  describe(resolveMigrationsDir, () => {
+    it('resolves the directory', () => {
+      expect(resolveMigrationsDir('backend')).toEqual(
+        expect.stringMatching(/\/backend\/migrations/),
+      );
+    });
+  });
+
+  describe(runDatabaseMigrations, () => {
+    it('executes database migrations', async () => {
+      const database = createDb();
+      const migrationsDir = resolveMigrationsDir('backend');
+
+      await expect(
+        runDatabaseMigrations(database, migrationsDir),
+      ).resolves.toBeInstanceOf(Array);
+    });
+  });
+});

--- a/packages/backend/src/database/migrations.ts
+++ b/packages/backend/src/database/migrations.ts
@@ -1,0 +1,22 @@
+import path from 'path';
+import Knex from 'knex';
+
+export function resolveMigrationsDir(pkgName: string) {
+  return path.resolve(
+    require.resolve(`${pkgName}/package.json`),
+    '../migrations',
+  );
+}
+
+export async function runDatabaseMigrations(
+  database: Knex,
+  migrationsDir: string,
+) {
+  const result = await database.migrate.latest({
+    directory: migrationsDir,
+  });
+
+  await database.destroy();
+
+  return result;
+}

--- a/packages/backend/src/database/postgres.test.ts
+++ b/packages/backend/src/database/postgres.test.ts
@@ -1,0 +1,169 @@
+import { ConfigReader } from '@backstage/config';
+import {
+  getPgConnectionConfig,
+  hasPostgresConnection,
+  parsePgDatabaseUrl,
+} from './postgres';
+
+describe('database connection', () => {
+  const createConfig = (data: any = {}) =>
+    ConfigReader.fromConfigs([{ context: '', data: { backend: data } }]);
+
+  describe(hasPostgresConnection, () => {
+    it('returns false when no postgres variables are present', () => {
+      expect(hasPostgresConnection(createConfig())).toBeFalsy();
+    });
+
+    it('returns true when all postgres variables are present', () => {
+      expect(
+        hasPostgresConnection(
+          createConfig({
+            POSTGRES_HOST: 'somehost',
+            POSTGRES_USER: 'postgres',
+            POSTGRES_PASSWORD: 'pass',
+          }),
+        ),
+      ).toBeTruthy();
+    });
+
+    it('returns false when not all postgres variables are present', () => {
+      expect(
+        hasPostgresConnection(
+          createConfig({
+            POSTGRES_HOST: 'somehost',
+          }),
+        ),
+      ).toBeFalsy();
+    });
+
+    it('returns true when postgres database url is present', () => {
+      expect(
+        hasPostgresConnection(
+          createConfig({
+            POSTGRES_URL: 'postgresql://postgres@localhost:5432/dbname',
+          }),
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  describe(getPgConnectionConfig, () => {
+    it('returns a knex connectin config for postgres variables', () => {
+      expect(
+        getPgConnectionConfig(
+          createConfig({
+            POSTGRES_HOST: 'somehost',
+            POSTGRES_USER: 'postgres',
+            POSTGRES_PASSWORD: 'pass',
+          }),
+        ),
+      ).toEqual({
+        host: 'somehost',
+        user: 'postgres',
+        password: 'pass',
+        port: 5432,
+        database: undefined,
+      });
+    });
+
+    it('returns a knex connection config for postgres database url', () => {
+      expect(
+        getPgConnectionConfig(
+          createConfig({
+            POSTGRES_URL: 'postgresql://postgres:pass@localhost:5432/dbname',
+          }),
+        ),
+      ).toEqual({
+        host: 'localhost',
+        user: 'postgres',
+        password: 'pass',
+        port: 5432,
+        database: 'dbname',
+      });
+    });
+  });
+
+  describe(parsePgDatabaseUrl, () => {
+    it('parses a connection string uri ', () => {
+      expect(
+        parsePgDatabaseUrl('postgresql://postgres:pass@foobar:5432/dbname'),
+      ).toEqual({
+        host: 'foobar',
+        user: 'postgres',
+        password: 'pass',
+        port: 5432,
+        database: 'dbname',
+      });
+    });
+
+    it('does not require password', () => {
+      expect(
+        parsePgDatabaseUrl('postgresql://postgres@localhost:5432/dbname'),
+      ).toEqual({
+        host: 'localhost',
+        user: 'postgres',
+        password: '',
+        port: 5432,
+        database: 'dbname',
+      });
+    });
+
+    it('accepts empty password', () => {
+      expect(
+        parsePgDatabaseUrl('postgresql://postgres:@localhost:5432/dbname'),
+      ).toEqual({
+        host: 'localhost',
+        user: 'postgres',
+        password: '',
+        port: 5432,
+        database: 'dbname',
+      });
+    });
+
+    it('defaults port number', () => {
+      expect(
+        parsePgDatabaseUrl('postgresql://postgres:pass@foobar/dbname'),
+      ).toEqual({
+        host: 'foobar',
+        user: 'postgres',
+        password: 'pass',
+        port: 5432,
+        database: 'dbname',
+      });
+    });
+
+    it('does not require a database', () => {
+      expect(parsePgDatabaseUrl('postgresql://postgres:pass@foobar')).toEqual({
+        host: 'foobar',
+        user: 'postgres',
+        password: 'pass',
+        port: 5432,
+        database: '',
+      });
+    });
+
+    it('ignores extra query parameters', () => {
+      expect(
+        parsePgDatabaseUrl(
+          'postgresql://postgres:pass@foobar:5432/dbname?sslmode=require',
+        ),
+      ).toEqual({
+        host: 'foobar',
+        user: 'postgres',
+        password: 'pass',
+        port: 5432,
+        database: 'dbname',
+      });
+    });
+
+    it('fails for invalid connection uri', () => {
+      expect(() => parsePgDatabaseUrl('foo')).toThrow('Invalid URL: foo');
+    });
+
+    it('fails for invalid protocol', () => {
+      expect(() =>
+        parsePgDatabaseUrl('foo://postgres:@localhost:5432/dbname'),
+      ).toThrow('Invalid database protocol: foo');
+    });
+  });
+});

--- a/packages/backend/src/database/postgres.ts
+++ b/packages/backend/src/database/postgres.ts
@@ -1,0 +1,52 @@
+import knex, { PgConnectionConfig } from 'knex';
+import { Config } from '@backstage/config';
+
+export function hasPostgresConnection(config: Config): boolean {
+  return (
+    ['POSTGRES_USER', 'POSTGRES_HOST', 'POSTGRES_PASSWORD'].every(key =>
+      config.getOptional(`backend.${key}`),
+    ) || !!config.getOptional(`backend.POSTGRES_URL`)
+  );
+}
+
+export function getPgConnectionConfig(
+  config: Config,
+  dbName?: string,
+): knex.PgConnectionConfig {
+  const databaseUrl = config.getOptionalString('backend.POSTGRES_URL');
+
+  if (databaseUrl) {
+    const pgConfig = parsePgDatabaseUrl(databaseUrl);
+    const { database, ...dbConfig } = pgConfig;
+
+    return {
+      ...dbConfig,
+      ...(dbName !== undefined ? { database: dbName } : { database: database }),
+    };
+  }
+
+  return {
+    host: config.getString('backend.POSTGRES_HOST'),
+    user: config.getString('backend.POSTGRES_USER'),
+    password: config.getString('backend.POSTGRES_PASSWORD'),
+    port: config.getOptionalNumber('backend.POSTGRES_PORT') || 5432,
+    database: dbName,
+  };
+}
+
+export function parsePgDatabaseUrl(databaseUrl: string): PgConnectionConfig {
+  const dbUrl = new URL(databaseUrl);
+
+  const scheme = dbUrl.protocol?.substr(0, dbUrl.protocol?.length - 1);
+  if (scheme !== 'postgresql') {
+    throw new Error(`Invalid database protocol: ${scheme}`);
+  }
+
+  return {
+    host: dbUrl.hostname,
+    port: Number(dbUrl.port || 5432),
+    user: dbUrl.username,
+    password: dbUrl.password,
+    database: dbUrl.pathname.slice(1),
+  };
+}


### PR DESCRIPTION
#### Why?

The database code in the `backend` is a bit verbose. This PR is an attempt to demonstrate how it could be dry'd up a bit. It also adds migrations to create databases along with support for `postgres` uri connection strings.

#### What?

- New `database` module in `packages/backend/src/database` which includes:
  - `createDatabase` to create either a `pg` or `sqlite` knex instance
  - `runDatabaseMigrations` helper that will can be used to run migrations
- Add support for using a postgres url connection string with `backend.POSTGRES_URL`. If found, this will take precedence over the individual postgres config values.
- Updated the `backend` to use the `createDatabase` to dry up the create of the backend
- Updated the `backend` to run migrations on load
- Added knex migrations in the `backend` to create required databases. This would assume a default database to contain the migrations table (e.g. `backstage`).

#### Open Questions

- Could some of this code be ported into the `spotify/backstage` repo?
- Can the `knexfile` and migrations be created with TypeScript without having issues at runtime? Possibly have the build transpose them to CJS.
- Would it make sense to include the create database migrations as part of backstage core? Possibly generate them as part of the cli `create-app` template.
